### PR TITLE
refactor: merge specific ISO TP options into optional config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Rust Semantic Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
+### Added
+- Added `UdsSocketOptions::vw()` helper to build VW-specific ISO-TP options while keeping the main API generic.
+
+### Changed
+- **BREAKING**:`UdsClient::new` requires an explicit `UdsSocketOptions`
+
+### Removed
+- **BREAKING**: `new_vw` constructor; use `new` with `UdsSocketOptions::vw()` instead
 
 ## [0.2.1] - 2026-03-14
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "uds-rs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bitflags 2.11.0",
  "embedded-can",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uds-rs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = [
     "Jakub Jíra <jakub.jira@protonmail.com>",

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ with the one you have set-up.
 
 use embedded_can::StandardId;
 use log::{error, info};
-use uds_rs::{ResetType, UdsClient, UdsError};
+use uds_rs::{ResetType, UdsClient, UdsError, UdsSocketOptions};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), UdsError> {
     env_logger::init();
-    // Create client
+    // Create client wtih default options
     let c = UdsClient::new(
         "can0",
         StandardId::new(0x774).expect("Invalid src id"),
         StandardId::new(0x70A).expect("Invalid dst id"),
-        None,
+        UdsSocketOptions::default(),
     )?;
 
     // read data by identifier (ecu VIN)
@@ -82,7 +82,8 @@ async fn main() -> Result<(), UdsError> {
     Ok(())
 }
 ```
-### Example with specific ISO-TP configuration
+
+#### Example with specific ISO-TP configuration
 
 ```rust
 // To run the example make sure to set-up a CAN interface first!
@@ -96,17 +97,18 @@ use uds_rs::{ResetType, UdsClient, UdsError, UdsSocketOptions};
 async fn main() -> Result<(), UdsError> {
     env_logger::init();
     // Create client with VW specific options
-    let socket_options = Some(UdsSocketOptions::vw()?);
+    let socket_options = UdsSocketOptions::vw()?;
     let c = UdsClient::new(
         "can0",
         StandardId::new(0x774).expect("Invalid src id"),
         StandardId::new(0x70A).expect("Invalid dst id"),
         socket_options,
     )?;
+
+    Ok(())
+
 }
 ```
-
-    let socket_options = Some(UdsSocketOptions::vw()?);
 
 ## Notes for development
 ### Communication architecture

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ with the one you have set-up.
 
 use embedded_can::StandardId;
 use log::{error, info};
-use uds_rs::{UdsClient, UdsError, ResetType};
+use uds_rs::{ResetType, UdsClient, UdsError};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), UdsError> {
@@ -45,6 +45,7 @@ async fn main() -> Result<(), UdsError> {
         "can0",
         StandardId::new(0x774).expect("Invalid src id"),
         StandardId::new(0x70A).expect("Invalid dst id"),
+        None,
     )?;
 
     // read data by identifier (ecu VIN)
@@ -81,6 +82,32 @@ async fn main() -> Result<(), UdsError> {
     Ok(())
 }
 ```
+### Example with specific ISO-TP configuration
+
+```rust
+// To run the example make sure to set-up a CAN interface first!
+
+use embedded_can::StandardId;
+use log::{error, info};
+use uds_rs::{ResetType, UdsClient, UdsError, UdsSocketOptions};
+
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), UdsError> {
+    env_logger::init();
+    // Create client with VW specific options
+    let socket_options = Some(UdsSocketOptions::vw()?);
+    let c = UdsClient::new(
+        "can0",
+        StandardId::new(0x774).expect("Invalid src id"),
+        StandardId::new(0x70A).expect("Invalid dst id"),
+        socket_options,
+    )?;
+}
+```
+
+    let socket_options = Some(UdsSocketOptions::vw()?);
+
 ## Notes for development
 ### Communication architecture
 Current communication architecture is strictly bounded request-response together. It would be

--- a/examples/basic_functionality.rs
+++ b/examples/basic_functionality.rs
@@ -8,7 +8,7 @@ use uds_rs::{ResetType, UdsClient, UdsError, UdsSocketOptions};
 async fn main() -> Result<(), UdsError> {
     env_logger::init();
     // Create client
-    let socket_options = Some(UdsSocketOptions::vw()?);
+    let socket_options = UdsSocketOptions::vw()?;
     let c = UdsClient::new(
         "can0",
         StandardId::new(0x774).expect("Invalid src id"),

--- a/examples/basic_functionality.rs
+++ b/examples/basic_functionality.rs
@@ -2,16 +2,18 @@
 
 use embedded_can::StandardId;
 use log::{error, info};
-use uds_rs::{ResetType, UdsClient, UdsError};
+use uds_rs::{ResetType, UdsClient, UdsError, UdsSocketOptions};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), UdsError> {
     env_logger::init();
     // Create client
+    let socket_options = Some(UdsSocketOptions::vw()?);
     let c = UdsClient::new(
         "can0",
         StandardId::new(0x774).expect("Invalid src id"),
         StandardId::new(0x70A).expect("Invalid dst id"),
+        socket_options,
     )?;
 
     // read data by identifier (ecu VIN)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,18 @@
 //!
 //! use embedded_can::StandardId;
 //! use log::{error, info};
-//! use uds_rs::{UdsClient, UdsError, ResetType};
+//! use uds_rs::{ResetType, UdsClient, UdsError, UdsSocketOptions};
 //!
 //! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<(), UdsError> {
 //!     env_logger::init();
 //!     // Create client
+//!     let socket_options = Some(UdsSocketOptions::vw()?);
 //!     let c = UdsClient::new(
 //!         "can0",
 //!         StandardId::new(0x774).expect("Invalid src id"),
 //!         StandardId::new(0x70A).expect("Invalid dst id"),
+//!         socket_options,
 //!     )?;
 //!
 //!     // read data by identifier (ecu VIN)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,12 @@
 //! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<(), UdsError> {
 //!     env_logger::init();
-//!     // Create client
-//!     let socket_options = Some(UdsSocketOptions::vw()?);
+//!     // Create client wtih default options
 //!     let c = UdsClient::new(
 //!         "can0",
 //!         StandardId::new(0x774).expect("Invalid src id"),
 //!         StandardId::new(0x70A).expect("Invalid dst id"),
-//!         socket_options,
+//!         UdsSocketOptions::default(),
 //!     )?;
 //!
 //!     // read data by identifier (ecu VIN)
@@ -70,6 +69,34 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ### Example with specific ISO-TP configuration
+//!
+//! ```no_run
+//! // To run the example make sure to set-up a CAN interface first!
+//!
+//! use embedded_can::StandardId;
+//! use log::{error, info};
+//! use uds_rs::{ResetType, UdsClient, UdsError, UdsSocketOptions};
+//!
+//!
+//! #[tokio::main(flavor = "current_thread")]
+//! async fn main() -> Result<(), UdsError> {
+//!     env_logger::init();
+//!     // Create client with VW specific options
+//!     let socket_options = UdsSocketOptions::vw()?;
+//!     let c = UdsClient::new(
+//!         "can0",
+//!         StandardId::new(0x774).expect("Invalid src id"),
+//!         StandardId::new(0x70A).expect("Invalid dst id"),
+//!         socket_options,
+//!     )?;
+//!
+//!     Ok(())
+//!
+//! }
+//! ```
+//!
 //! # Notes for development
 //! ## Communication architecture
 //! Current communication architecture is strictly bounded request-response together. It would be

--- a/src/uds.rs
+++ b/src/uds.rs
@@ -124,7 +124,7 @@ impl UdsClient {
         canifc: &str,
         src: impl Into<Id>,
         dst: impl Into<Id>,
-        options: Option<UdsSocketOptions>,
+        options: UdsSocketOptions,
     ) -> Result<UdsClient, UdsError> {
         Ok(UdsClient {
             socket: UdsSocket::new(canifc, src, dst, options)?,

--- a/src/uds.rs
+++ b/src/uds.rs
@@ -124,19 +124,10 @@ impl UdsClient {
         canifc: &str,
         src: impl Into<Id>,
         dst: impl Into<Id>,
+        options: Option<UdsSocketOptions>,
     ) -> Result<UdsClient, UdsError> {
         Ok(UdsClient {
-            socket: UdsSocket::new(canifc, src, dst)?,
-        })
-    }
-
-    pub fn new_vw(
-        canifc: &str,
-        src: impl Into<Id>,
-        dst: impl Into<Id>,
-    ) -> Result<UdsClient, UdsError> {
-        Ok(UdsClient {
-            socket: UdsSocket::new_vw(canifc, src, dst)?,
+            socket: UdsSocket::new(canifc, src, dst, options)?,
         })
     }
 

--- a/src/uds/communication.rs
+++ b/src/uds/communication.rs
@@ -52,6 +52,12 @@ pub struct UdsSocketOptions {
 }
 
 impl UdsSocketOptions {
+    pub fn is_default(&self) -> bool {
+        self.isotp_options.is_none()
+            && self.rx_flow_control_options.is_none()
+            && self.link_layer_options.is_none()
+    }
+
     pub fn vw() -> Result<Self, UdsCommunicationError> {
         let mut initial_flags = IsoTpBehaviour::CAN_ISOTP_RX_PADDING;
         initial_flags.set(IsoTpBehaviour::CAN_ISOTP_TX_PADDING, true);
@@ -83,13 +89,17 @@ impl UdsSocket {
         ifname: &str,
         src: impl Into<Id>,
         dst: impl Into<Id>,
-        options: Option<UdsSocketOptions>,
+        options: UdsSocketOptions,
     ) -> Result<UdsSocket, UdsCommunicationError> {
         let src = src.into();
         let dst = dst.into();
 
-        match options {
-            Some(options) => Ok(UdsSocket {
+        if options.is_default() {
+            Ok(UdsSocket {
+                isotp_socket: tokio_socketcan_isotp::IsoTpSocket::open(ifname, src, dst)?,
+            })
+        } else {
+            Ok(UdsSocket {
                 isotp_socket: tokio_socketcan_isotp::IsoTpSocket::open_with_opts(
                     ifname,
                     src,
@@ -98,10 +108,7 @@ impl UdsSocket {
                     options.rx_flow_control_options,
                     options.link_layer_options,
                 )?,
-            }),
-            None => Ok(UdsSocket {
-                isotp_socket: tokio_socketcan_isotp::IsoTpSocket::open(ifname, src, dst)?,
-            }),
+            })
         }
     }
 

--- a/src/uds/communication.rs
+++ b/src/uds/communication.rs
@@ -8,6 +8,7 @@
 //!
 
 use std::time::Duration;
+
 pub use tokio_socketcan_isotp::{
     Error, ExtendedId, FlowControlOptions, Id, IsoTpBehaviour, IsoTpOptions, LinkLayerOptions,
     StandardId, TxFlags,
@@ -43,61 +44,65 @@ pub struct UdsSocket {
     isotp_socket: tokio_socketcan_isotp::IsoTpSocket,
 }
 
+#[derive(Default)]
+pub struct UdsSocketOptions {
+    pub isotp_options: Option<IsoTpOptions>,
+    pub rx_flow_control_options: Option<FlowControlOptions>,
+    pub link_layer_options: Option<LinkLayerOptions>,
+}
+
+impl UdsSocketOptions {
+    pub fn vw() -> Result<Self, UdsCommunicationError> {
+        let mut initial_flags = IsoTpBehaviour::CAN_ISOTP_RX_PADDING;
+        initial_flags.set(IsoTpBehaviour::CAN_ISOTP_TX_PADDING, true);
+
+        let mut isotp_options = IsoTpOptions::new(
+            initial_flags,
+            Duration::from_secs(1),
+            u8::MAX,
+            0x55,
+            0xAA,
+            u8::MAX,
+        )
+        .map_err(|_| UdsCommunicationError::SocketCreationError)?;
+
+        let mut runtime_flags = IsoTpBehaviour::CAN_ISOTP_RX_PADDING;
+        runtime_flags.set(IsoTpBehaviour::CAN_ISOTP_TX_PADDING, true);
+        isotp_options.set_flags(runtime_flags);
+
+        Ok(Self {
+            isotp_options: Some(isotp_options),
+            rx_flow_control_options: None,
+            link_layer_options: None,
+        })
+    }
+}
+
 impl UdsSocket {
     pub fn new(
         ifname: &str,
         src: impl Into<Id>,
         dst: impl Into<Id>,
+        options: Option<UdsSocketOptions>,
     ) -> Result<UdsSocket, UdsCommunicationError> {
-        Ok(UdsSocket {
-            isotp_socket: tokio_socketcan_isotp::IsoTpSocket::open(ifname, src, dst)?,
-        })
-    }
+        let src = src.into();
+        let dst = dst.into();
 
-    pub fn new_vw(
-        ifname: &str,
-        src: impl Into<Id>,
-        dst: impl Into<Id>,
-    ) -> Result<UdsSocket, UdsCommunicationError> {
-        let mut behav = IsoTpBehaviour::CAN_ISOTP_RX_PADDING;
-        behav.set(IsoTpBehaviour::CAN_ISOTP_TX_PADDING, true);
-
-        let tp_options =
-            IsoTpOptions::new(behav, Duration::from_secs(1), u8::MAX, 0x55, 0xAA, u8::MAX);
-
-        let mut behav = IsoTpBehaviour::CAN_ISOTP_RX_PADDING;
-        behav.set(IsoTpBehaviour::CAN_ISOTP_TX_PADDING, true);
-        let mut options = None;
-
-        match tp_options {
-            Ok(mut o) => {
-                o.set_flags(behav);
-                options = Some(o);
-            }
-            Err(_) => println!("Cannot set options!"),
+        match options {
+            Some(options) => Ok(UdsSocket {
+                isotp_socket: tokio_socketcan_isotp::IsoTpSocket::open_with_opts(
+                    ifname,
+                    src,
+                    dst,
+                    options.isotp_options,
+                    options.rx_flow_control_options,
+                    options.link_layer_options,
+                )?,
+            }),
+            None => Ok(UdsSocket {
+                isotp_socket: tokio_socketcan_isotp::IsoTpSocket::open(ifname, src, dst)?,
+            }),
         }
-        let uds_socket = UdsSocket::new_with_opts(ifname, src, dst, options, None, None)?;
-        Ok(uds_socket)
-    }
-
-    pub fn new_with_opts(
-        ifname: &str,
-        src: impl Into<Id>,
-        dst: impl Into<Id>,
-        isotp_options: Option<IsoTpOptions>,
-        rx_flow_control_options: Option<FlowControlOptions>,
-        link_layer_options: Option<LinkLayerOptions>,
-    ) -> Result<UdsSocket, UdsCommunicationError> {
-        Ok(UdsSocket {
-            isotp_socket: tokio_socketcan_isotp::IsoTpSocket::open_with_opts(
-                ifname,
-                src,
-                dst,
-                isotp_options,
-                rx_flow_control_options,
-                link_layer_options,
-            )?,
-        })
     }
 
     pub async fn send(&self, payload: &[u8]) -> Result<(), UdsCommunicationError> {


### PR DESCRIPTION
This makes sure we only have one entry point: `fn new()` but still specific configurations can be given. The VW configuration can be obtained from this crate for easy set-up.

This is a BREAKING CHANGE because a new argument should be added to `new()`.